### PR TITLE
Fix identify_person_category

### DIFF
--- a/R/HouseholdSize.R
+++ b/R/HouseholdSize.R
@@ -12,19 +12,26 @@
 #' @examples
 get_household_size_conversion <- function() {
     MAE_coeff <- tibble::as_tibble(list(
-        children_under_4 = 0.5,
-        children_4to10 = 0.75,
-        males11to24 = 0.85,
-        females11to24 = 0.75,
-        males11to50=0.925,
-        females11to50=0.805,
-        males25to50 = 1,
-        females25to50 = 0.86,
-        female_25_to_50 = 0.86,
-        male_50_plus = 0.73,
-        malesover50 = 0.73,
-        female_50_plus = 0.6,
-        femalesover50 = 0.6
+      children_under4 = 0.5, #current
+      children_under_4 = 0.5,
+      children_4to10 = 0.75, #current
+      males11to24 = 0.85,
+      males_11to24 = 0.85, #current
+      females11to24 = 0.75,
+      females_11to24 = 0.75, #current
+      males11to50=0.925,
+      females11to50=0.805,
+      males25to50 = 1,
+      males_25to50 = 1, #current
+      females25to50 = 0.86,
+      female_25_to_50 = 0.86,
+      females_25to50 = 0.86, #current
+      male_50_plus = 0.73,
+      malesover50 = 0.73,
+      males_50plus = 0.73, #current
+      female_50_plus = 0.6,
+      femalesover50 = 0.6,
+      females_50plus=0.6 #current
     ))
     return(MAE_coeff)
 }
@@ -50,19 +57,19 @@ identify_person_category <- function(age, gender) {
     vector <- rep(NA, length(gender))
     gender <- substr(tolower(gender),0,1)
 
-    vector[age < 4] <- "children_under_4"
-    vector[age >= 4 & age < 1] <- "children_4to10"
-    vector[age > 11 & age <= 24 & gender == "m"] <- "males11to24"
-    vector[age > 11 & age <= 24 & gender == "f"] <- "females11to24"
-    vector[age > 24 & age <= 50 & gender == "m"] <- "males25to50"
-    vector[age > 24 & age <= 50 & gender == "f"] <- "female_25_to_50"
-    vector[age > 50 & gender == "m"] <- "male_50_plus"
-    vector[age > 50 & gender == "f"] <- "female_50_plus"
+    vector[age < 4] <- "children_under4"
+    vector[age >= 4 & age < 11] <- "children_4to10"
+    vector[age >= 11 & age <= 24 & gender == "m"] <- "males_11to24"
+    vector[age >= 11 & age <= 24 & gender == "f"] <- "females_11to24"
+    vector[age > 24 & age <= 50 & gender == "m"] <- "males_25to50"
+    vector[age > 24 & age <= 50 & gender == "f"] <- "females_25to50"
+    vector[age > 50 & gender == "m"] <- "males_50plus"
+    vector[age > 50 & gender == "f"] <- "females_50plus"
 
     return(vector)
 }
 
-#' Household roster to catgeries
+#' Household roster to categories
 #'
 #' Rpackage file: HouseholdSize.R
 #'
@@ -103,8 +110,8 @@ household_roster_to_categories <- function(data) {
 #' @examples
 household_roster_to_wide <- function(data) {
     categorical_format <- household_roster_to_categories(data)
-    categories <- colnames(get_household_size_conversion())
-
+    # getting the categories used in identify_person_category()
+    categories <- unique(identify_person_category(rep(1:100,2), rep(c("F", "M"), each=100)))
     categorical_format <- sapply(categories, function(x) rowSums(categorical_format == x, na.rm = T))
     categorical_format <- tibble::as_tibble(categorical_format)
     return(categorical_format)

--- a/tests/testthat/test-HouseholdSize.R
+++ b/tests/testthat/test-HouseholdSize.R
@@ -27,9 +27,9 @@ testthat::test_that("Checking can convert household roster to categories", {
 
 
 
-    expected_result <- tibble::as_tibble(list(household_person_category_1=c("males25to50","female_25_to_50","males25to50",NA),
-                                      household_person_category_2=c("female_25_to_50","females11to24","children_under_4","male_50_plus"),
-                                      household_person_category_3=c("males11to24","males11to24",NA,NA)))
+    expected_result <- tibble::as_tibble(list(household_person_category_1=c("males_25to50","females_25to50","males_25to50",NA),
+                                      household_person_category_2=c("females_25to50","females_11to24","children_under4","males_50plus"),
+                                      household_person_category_3=c("males_11to24","males_11to24",NA,NA)))
 
     actual_result <- household_roster_to_categories(data)
 
@@ -58,20 +58,15 @@ testthat::test_that("Can map household roster into traditional category format",
                            person_work_away_3=c("stay","stay",NA,NA)
     ))
 
-    expected_result <- structure(list(children_under_4 = c(0, 0, 1, 0),
+    expected_result <- structure(list(children_under4 = c(0, 0, 1, 0),
                                       children_4to10 = c(0, 0, 0, 0),
-                                      males11to24 = c(0, 1, 0, 0),
-                                      females11to24 = c(0, 1, 0, 0),
-                                      males11to50=c(0, 0, 0, 0),
-                                      females11to50=c(0, 0, 0, 0),
-                                      males25to50 = c(2, 0, 1, 0),
-                                      females25to50 = c(0, 0, 0, 0),
-                                      female_25_to_50 = c(1, 1, 0, 0),
-                                      male_50_plus = c(0, 0, 0, 1),
-                                      malesover50 = c(0, 0, 0, 0),
-
-                                      female_50_plus = c(0, 0, 0, 0),
-                                      femalesover50 = c(0, 0, 0, 0)
+                                      females_11to24 = c(0, 1, 0, 0),
+                                      females_25to50 = c(1, 1, 0, 0),
+                                      females_50plus = c(0, 0, 0, 0),
+                                      males_11to24 = c(0, 1, 0, 0),
+                                      males_25to50 = c(2, 0, 1, 0),
+                                      males_50plus = c(0, 0, 0, 1)
+                                      
     ),
                                  row.names = c(NA, -4L), class = c("tbl_df", "tbl", "data.frame"))
 
@@ -128,14 +123,14 @@ testthat::test_that("Can calculate MAE score",{
 })
 
 testthat::test_that("Can calculate household size in terms of members",{
-    data <- tibble::as_tibble(list(children_under_4=c(1,0,0,0),
+    data <- tibble::as_tibble(list(children_under4=c(1,0,0,0),
                            children_4to10=c(2,3,3,3),
-                           males11to24=c(1,2,3,4),
-                           females11to24=c(4,3,2,1),
-                           males25to50=c(2,2,2,2),
-                           female_25_to_50=c(1,1,1,1),
-                           male_50_plus=c(0,1,1,3),
-                           female_50_plus=c(0,3,2,1)))
+                           males_11to24=c(1,2,3,4),
+                           females_11to24=c(4,3,2,1),
+                           males_25to50=c(2,2,2,2),
+                           females_25to50=c(1,1,1,1),
+                           males_50plus=c(0,1,1,3),
+                           females_50plus=c(0,3,2,1)))
     expected_result <- c(11, 15, 14, 15)
 
     actual_result <- calculate_household_size_members(data)


### PR DESCRIPTION
children_4to10 were not identified correctly.
What started as a little fix ended up as a re-harmonization of the household categories (males and females always in plural, gender separated from age by '_').
I also updated the testthat functions, and I hope it won´t create issues of compatibility with older dataset.